### PR TITLE
Correccion ruta documentacion (con acento)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -65,9 +65,9 @@ def remove_html(s):
 def getConectividad():
 	return render_template("conectividad.html")
 
-@app.route('/documentación')
+@app.route('/documentacion')
 def getDocumentacion():
-	return render_template("documentación.html")
+	return render_template("documentacion.html")
 
 @app.route('/economia-digital')
 def getEconomia_Digital():


### PR DESCRIPTION
Cuando se intentaba acceder a la ruta /documentacion desde el front, daba un error 404 por que en el backend estaba con acento "documentación"